### PR TITLE
Change flash command

### DIFF
--- a/doc/en/firmware.md
+++ b/doc/en/firmware.md
@@ -17,7 +17,7 @@ make plaid:default
 #### Build and burn to plaid
 After entering bootloader mode,
 ```
-make plaid:default:program
+make plaid:default:flash
 ```
 
 #### avr-gcc version
@@ -27,7 +27,7 @@ brew uninstall avr-gcc
 brew install avr-gcc@7
 brew link --force avr-gcc@7
 ```
-And then re-run `make plaid:default:program`.
+And then re-run `make plaid:default:flash`.
 
 ## Test with wire
 When you burn default keymap, test without soldering switches.   

--- a/doc/jp/firmware.md
+++ b/doc/jp/firmware.md
@@ -17,7 +17,7 @@ make plaid:default
 #### ビルドしてPlaidへ書き込む
 Plaidをブートローダモードにしてから
 ```
-make plaid:default:program
+make plaid:default:flash
 ```
 
 ## ジャンパー線でテスト


### PR DESCRIPTION
The old flash command `make plaid:default:program` is not working with the newer qmk firmware release.
Right command is `make plaid:default:flash`.